### PR TITLE
Add support for overriding existing command in task definition

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'Override the container entrypoint to use for running the container'
     required: false
     default: ''
+  command:
+    description: 'Override the container command to use for running the container'
+    required: false
+    default: ''
   log-group:
     description: 'Override the container log group to use for running the container. This defaults to /ecs/<task-family>'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -1153,6 +1153,7 @@ async function run() {
     const imageURI = core.getInput('image', { required: true });
     const taskFamily = core.getInput('task-family', { required: true });
     const entryPoint = core.getInput('entry-point', { required: false }) || '';
+    const command = core.getInput('command', { required: false }) || '';
     const logGroup = core.getInput('log-group', { required: false }) || '';
     const memory = core.getInput('memory', { required: false }) || '';
     const cpu = core.getInput('cpu', { required: false }) || '';
@@ -1185,6 +1186,9 @@ async function run() {
 
     if (entryPoint) {
       containerDef.entryPoint = entryPoint.split(' ');
+    }
+    if (command) {
+      containerDef.command = command.split(' ');
     }
     if (logGroup) {
       containerDef.logConfiguration.options['awslogs-group'] = logGroup;


### PR DESCRIPTION
Although the `entry-point` and the `command` can both execute a command within a container, their semantics are different, and tooling (including ECS, AFAICT) usually provides easy overrides for the command, less so for entry-point. 

https://docs.docker.com/engine/reference/builder/#cmd

When this action supports patching commands in task definitions, I can ensure that our container builds don't define a static entry point, and use command instead. 

That allows for niceties like using a base container/task, and launching on the fly with an arbitrary script, eg for dumping the db to S3, starting a rails console, etc. 